### PR TITLE
fix the crash when clicking the play button after app resumed from background

### DIFF
--- a/app/src/main/java/ir/imn/audiovisualizer/MainActivity.kt
+++ b/app/src/main/java/ir/imn/audiovisualizer/MainActivity.kt
@@ -82,6 +82,17 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStop() {
         super.onStop()
+        
+        if (mediaPlayer.isPlaying) {
+            mediaPlayer.pause()
+            playControlButton.text = getString(R.string.play)
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        mediaPlayer.stop()
         mediaPlayer.release()
     }
 


### PR DESCRIPTION
Hi @ImnIrdst ,

I just found that if app got resumed from background and I clicked the button to play again, there will be a crash related to illegal state of `MediaPlayer`.